### PR TITLE
71: Save DOB and gender

### DIFF
--- a/showup/forms.py
+++ b/showup/forms.py
@@ -9,11 +9,9 @@ class CustomSignupForm(SignupForm):
     gender = forms.CharField(max_length=255)
     email = forms.EmailField()
 
-    def signup(self, request, user):
-        user.first_name = self.cleaned_data['first_name']
-        user.last_name = self.cleaned_data['last_name']
+    def save(self, request):
+        user = super(CustomSignupForm, self).save(request) # this saves the built-in fields (first name, last name, email, password)
         user.date_of_birth = self.cleaned_data['date_of_birth']
         user.gender = self.cleaned_data['gender']
-        user.email = self.cleaned_data['email']
         user.save()
         return user


### PR DESCRIPTION
I changed the CustomSignupForm in accordance with allauth's documentation [here](https://django-allauth.readthedocs.io/en/latest/forms.html#signup-allauth-account-forms-signupform). I tested it locally and DOB and gender are now being written to the database when signing up, as desired.

Acceptance testing:
* Make a new user. Fill in all fields.
* Go to the admin interface, look at the newly created user.
* See that the information for all fields, including date of birth and gender, has been saved to the database.