### PR TITLE
#78: Page Redirection

### DIFF
--- a/showup/views.py
+++ b/showup/views.py
@@ -1,6 +1,6 @@
-from django.shortcuts import render
 from .models import Concert
 from django.contrib.auth.decorators import login_required
+from django.shortcuts import render
 
 
 def home(request):


### PR DESCRIPTION
# Description
If a non-authenticated user tries to access a page that requires authentication, such as the events page or a user profile, we want to redirect them to the login page. Then, after they log in, they should be redirected back to the original page they tried to access.

# How to test
1. Get the code from this PR. 
2. Run the server. Make sure you're logged out of ShowUp i.e. go to the homepage and log out, if necessary.
3. Go to the events/ URL. See that you're redirected to the login page.
4. Log in and see that you're redirected to the events page, as desired.
5. Log out.
6. Go to a user profile URL such as /u/1. See that you're redirected to the login page.
7. Log in and see that you're redirected to the user profile, as desired.