### PR TITLE
Fixed incorrectly split line in pull_seatgeek_data

### DIFF
--- a/showup/management/commands/pull_seatgeek_data.py
+++ b/showup/management/commands/pull_seatgeek_data.py
@@ -12,8 +12,10 @@ from datetime import datetime
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
-        base_url = ("https://api.seatgeek.com/2/events?client_id="
-        "MTg3MzUxNzB8MTU3MDE1NTY1OS45MQ&per_page=5000&taxonomies.name=concert")
+        base_url = (
+            "https://api.seatgeek.com/2/events?client_id="
+            "MTg3MzUxNzB8MTU3MDE1NTY1OS45MQ&per_page=5000&taxonomies.name=concert"
+        )
         borough_urls = {
             "BK": "&lat=40.643222&lon=-73.949258&range=5mi",
             "QN": "&lat=40.720977&lon=-73.810735&range=6.5mi",


### PR DESCRIPTION
There was a really long line in pull_seatgeek_data and flake8 complained about it. So I split it into several lines, but I did that incorrectly, and that broke pull_seatgeek_data.

So here I'm fixing it.