### PR TITLE
Session now expires in 12 hrs

### DIFF
--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -159,5 +159,5 @@ ACCOUNT_LOGOUT_REDIRECT_URL = "home"
 ACCOUNT_FORMS = {"signup": "showup.forms.CustomSignupForm"}
 
 # Session Timeout settings
-SESSION_EXPIRE_SECONDS = 60 * 12 * 12
+SESSION_EXPIRE_SECONDS = 60 * 60 * 12
 SESSION_EXPIRE_AFTER_LAST_ACTIVITY = True


### PR DESCRIPTION
### Description

Made adjustments timeout a session in 12hrs

### Testing Directions

Login as a user. Now the session doesn't timeout in 30secs. Press refresh after 30 secs it should still give the same page you are in. 

Wait for 12hrs without any activity and the session times out.


