### PR TITLE
PR for #107: Homepage Links to Event Stacks

### DIFF
--- a/showup/templates/home.html
+++ b/showup/templates/home.html
@@ -7,6 +7,16 @@
 {% if user.is_authenticated %}
     <p>Hi {{ user.email }}!</p>
 
+    <h5>Links to matching stacks for events I'm interested in:</h5>
+    {% for interested in user.interested.all %}
+      <p><a href="{% url 'event_stack' interested.id %}">{{ interested }}</a></p>
+    {% endfor %}
+
+    <h5>Links to matching stacks for events I'm going to:</h5>
+    {% for going in user.going.all %}
+      <p><a href="{% url 'event_stack' going.id %}">{{ going }}</a></p>
+    {% endfor %}
+
 {% else %}
     <p>You are not logged in</p>
     <a href="{% url 'account_login' %}">Log In</a> |

--- a/showup/urls.py
+++ b/showup/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path("accounts/", include("allauth.urls")),
     path("u/<int:id>", views.user, name="user"),
     path("u/<int:id>/edit", views.edit_profile, name="edit_profile"),
+    path("<int:eid>/match", views.event_stack, name="event_stack"),
 ]

--- a/showup/views.py
+++ b/showup/views.py
@@ -133,3 +133,7 @@ def edit_profile(request, id):
         form = CustomUserChangeForm(instance=request.user)
         args = {"form": form}
         return render(request, "edit_profile.html", args)
+
+
+def event_stack(request, eid):
+    pass


### PR DESCRIPTION
### Description

I added links on the homepage for the matching stacks for the events that the current user is interested in or going to.

### Testing Directions

```
python manage.py makemigrations
python manage.py migrate
python manage.py pull_seatgeek_data
```

1. Get the code for this PR
1. Run the Django server and go to the ShowUp homepage
1. Sign in and go to the Events page and click "interested" or "going to" on a few events, if you haven't already
1. Go to the home page and see that your events are listed and each event has a link:
![image](https://user-images.githubusercontent.com/13837978/67534113-9b280b00-f69a-11e9-9459-8da27efdf51a.png)
1. Click on one of the links and notice that its URL is `/<eid>/match`, as desired. Note that the page won't work, because that's part of issue #109, not this one.

### Miscellaneous Comments

*   The `event_stack` view is currently just a stub. @jawooson, when you do issue #109, replace the stub with your real view.

### Checklist

- [x] I ran `git merge develop` before submitting this PR.
- [x] I understand that I may have to run `git merge develop` again after submitting this PR since new changes may have been pulled into `develop`.
- [x] I understand that it is MY responsibility to make sure that this PR does not have any conflicts.
