### PR TITLE
Remove makemigrations from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ install:
     - pip install -r requirements.txt
 
 before_script:
-    - python manage.py makemigrations
     - python manage.py migrate
     - python manage.py collectstatic --noinput
 


### PR DESCRIPTION
### Description

No longer need to make migrations, removing from .travis.yml

### Testing Directions

```
python manage.py makemigrations
python manage.py migrate
python manage.py pull_seatgeek_data
```

### Checklist

- [x] I ran `git merge develop` before submitting this PR.
- [x] I understand that I may have to run `git merge develop` again after submitting this PR since new changes may have been pulled into `develop`.
- [x] I understand that it is MY responsibility to make sure that this PR does not have any conflicts.