### PR TITLE
Fixed order of Genre

### DIFF
--- a/showup/management/commands/pull_seatgeek_data.py
+++ b/showup/management/commands/pull_seatgeek_data.py
@@ -113,7 +113,7 @@ class Command(BaseCommand):
 
         # Add genres to Genre model.
 
-        for genre in reversed(genres):
+        for genre in genres:
             Genre(genre=genre).save()
 
         # Add genres to genres.txt.


### PR DESCRIPTION
### Description
Made changes to order the Genres alphabetically. 

### Testing Directions

Run the following commands:

```
python manage.py makemigrations
python manage.py migrate
python manage.py pull_seatgeek_data
python manage.py shell
from showup.models import Genre
Genre.objects.all()
```
Additionally, you can also view the changes at 'Profile/Edit Profile' all the genres are now populated alphabetically. 

### Miscellaneous Comments

*   Use backticks to write `code`.
*   Whatever else you feel like saying can go here.

### Checklist

- [ yes] I ran `git merge develop` before submitting this PR.
- [ yes] I understand that I may have to run `git merge develop` again after submitting this PR since new changes may have been pulled into `develop`.
- [ yes] I understand that it is MY responsibility to make sure that this PR does not have any conflicts.