### PR TITLE
change avatar size from 200 to 190

### DIFF
--- a/showup/templates/user.html
+++ b/showup/templates/user.html
@@ -12,7 +12,7 @@
                   <!-- Edit Image link only if its your account  -->
                   {% if user.id == requested_user.id %}
                   <div>
-                    <a href="{% url 'avatar_change' %}"><img src="{% avatar_url requested_user 200 %}"></a>
+                    <a href="{% url 'avatar_change' %}"><img src="{% avatar_url requested_user 190 %}"></a>
                   </div>
 
                   <!-- If its not your profile, cannot edit avatar -->


### PR DESCRIPTION
### Description

The professor's gravatar wouldn't load with size 200. It works with size 190.

### Testing Directions

```
./setup
python manage.py runserver
```

1.  Log in as `gcivil@nyu.edu` and navigate to "My Profile". See that his gravatar loads.

### Checklist

- [x] I have written tests which have maintained/increased test coverage.
- [x] I ran `git merge develop` before submitting this PR.
- [x] I understand that I may have to run `git merge develop` again after submitting this PR since new changes may have been pulled into `develop`.
- [x] I understand that it is MY responsibility to make sure that this PR does not have any conflicts.