### PR TITLE
Fixed titles and match card enhancement

### DIFF
--- a/showup/templates/home.html
+++ b/showup/templates/home.html
@@ -3,7 +3,17 @@
 {% block content %}
 
 {% if user.is_authenticated %}
-    <section class="pt-6 pt-md-8 pb-8 mb-md-8">
+<div class="text-center pt-7">
+<h2 class="font-weight-bold mb-0">
+  Howdy, {{ user.first_name }}.
+</h2>
+
+<!-- Text -->
+<h4 class="font-size-lg text-gray-700 mb-0">
+  Let's get you dancing ASAP.
+</h4>
+</div>
+    <section class="pt-6 pt-md-5 pb-8 mb-md-8">
         <div class="container">
           <div class="row">
             <div class="col-12">
@@ -12,14 +22,14 @@
                 <div class="col ml-n4">
 
                   <!-- Heading -->
-                  <h2 class="font-weight-bold mb-0">
+                  <!-- <h2 class="font-weight-bold mb-0">
                     Howdy, {{ user.first_name }}.
                   </h2>
 
                   <!-- Text -->
-                  <h4 class="font-size-lg text-gray-700 mb-0">
+                  <!-- <h4 class="font-size-lg text-gray-700 mb-0">
                     Let's get you dancing ASAP.
-                  </h4>
+                  </h4> -->
 
                 </div>
               </div> <!-- / .row -->

--- a/showup/templates/match.html
+++ b/showup/templates/match.html
@@ -9,7 +9,7 @@
 <section class="py-14 bg-white bg-between" style="background-image: url({% static 'dancing match.png' %}); background-position: center; background-repeat: no-repeat; background-size:cover;">
   <div class="container">
     <div class="row justify-content-center">
-      <div class="col-12 col-md-10 col-lg-7 text-center" data-aos="fade-up">
+      <div class="mr-1 lift col-12 col-md-10 col-lg-4 text-center" data-aos="fade-up">
 
         <div class="my-5">
           {% avatar swipee %}

--- a/showup/templates/matches.html
+++ b/showup/templates/matches.html
@@ -2,10 +2,10 @@
 {% load avatar_tags %}
 {% load static %}
 {% block content %}
-<div style = "position:relative; top:20px">
-<center><h2>Let's talk, shall we?</h2></center>
+<div class="text-center pt-7">
+<h2>Let's talk, shall we?</h2>
 </div>
-<section class="pt-6 pt-md-8 pb-8 mb-md-8">
+<section class="pt-6 pt-md-5 pb-8 mb-md-8">
   <div class="container">
     <div class="row">
       <div class="col-12">

--- a/showup/templates/squad.html
+++ b/showup/templates/squad.html
@@ -5,12 +5,14 @@
 
 {% block content %}
 
-<section class="pt-6 pt-md-8 pb-8 mb-md-8">
+<div class="text-center pt-7">
+<h2>Squad Up</h2>
+</div>
+<section class="pt-6 pt-md-5 pb-8 mb-md-8">
   <div class="container">
     <div class="row flex-grow-1 overflow-hidden">
       <div class="card shadow">
         <div class="card-body">
-          <h2 class="card-title text-center pb-5">Squad Up</h2>
           <div class="list-group-item shadow">
             <div class="row">
               {% for user in users %}


### PR DESCRIPTION
### Description

Fixed titles across `matches` `squad` and `Home` pages. Also made an enhancement to the match card on `match`

### Testing Directions

```
python manage.py migrate
python manage.py pull_seatgeek_data
python manage.py make_users
```

1)Goto the pages mentioned in the description and see that all the titles are aligned properly 
2)Goto match by giving 2 users or more as interested/going and enter the matching stack. Hover the mouse over user on matching stack. You should see that card fades up.

### Checklist

- [x] I have written tests which have maintained/increased test coverage.
- [x] I ran `git merge develop` before submitting this PR.
- [x] I understand that I may have to run `git merge develop` again after submitting this PR since new changes may have been pulled into `develop`.
- [x] I understand that it is MY responsibility to make sure that this PR does not have any conflicts.