### PR TITLE
PR for #6: Implement Messaging

### DIFF
--- a/showup/templates/match.html
+++ b/showup/templates/match.html
@@ -55,7 +55,7 @@
           <h4>You matched with {{match.first_name}}.</h4>
         </div>
         <div class="modal-footer">
-          <button type="button" class="btn btn-primary">Message</button>
+          <a class="btn btn-primary" href="{% url 'messages' user.squad.id match.squad.id %}">Message</a>
           <button type="button" class="btn btn-secondary">Keep Swiping</button>
         </div>
       </div>

--- a/showup/templates/matches.html
+++ b/showup/templates/matches.html
@@ -46,7 +46,7 @@
                       <!-- Text -->
                       <div class="text-gray-700">
                         {% avatar match.swipee %} &nbsp {{ match.swipee.first_name }}
-                          <a style = "position:relative; left:500px" href="#">Message</a> &nbsp &nbsp
+                          <a style = "position:relative; left:500px" href="{% url 'messages' user.squad.id match.swipee.squad.id %}">Message</a> &nbsp &nbsp
                           <a style = "position:relative; left:550px" href="{% url 'user' match.swipee.id %}">User Profile</a>
                       </div>
 

--- a/showup/templates/matches.html
+++ b/showup/templates/matches.html
@@ -46,7 +46,9 @@
                       <!-- Text -->
                       <div class="text-gray-700 row">
                         <div class="col">
-                        {% avatar match.swipee %} &nbsp {{ match.swipee.first_name }}
+                          {% avatar match.swipee %} &nbsp {{ match.swipe.first_name }}
+                        </div>
+                        <div class="col text-right">
                           <a style = "position:relative; top:26px" href="{% url 'messages' user.squad.id match.swipee.squad.id %}">Message</a> &nbsp &nbsp &nbsp
                           <a style = "position:relative; top:26px" href="{% url 'user' match.swipee.id %}">View Profile</a>
                         </div>

--- a/showup/templates/matches.html
+++ b/showup/templates/matches.html
@@ -47,8 +47,9 @@
                       <div class="text-gray-700 row">
                         <div class="col">
                         {% avatar match.swipee %} &nbsp {{ match.swipee.first_name }}
-                          <a style = "position:relative; left:500px" href="{% url 'messages' user.squad.id match.swipee.squad.id %}">Message</a> &nbsp &nbsp
-                          <a style = "position:relative; left:550px" href="{% url 'user' match.swipee.id %}">User Profile</a>
+                          <a style = "position:relative; top:26px" href="{% url 'messages' user.squad.id match.swipee.squad.id %}">Message</a> &nbsp &nbsp &nbsp
+                          <a style = "position:relative; top:26px" href="{% url 'user' match.swipee.id %}">View Profile</a>
+                        </div>
                       </div>
 
                     </div>

--- a/showup/templates/messages.html
+++ b/showup/templates/messages.html
@@ -1,0 +1,9 @@
+{% extends 'header.html' %}
+{% block content %}
+<div class="container">
+    <div class="col-12">
+        <iframe src="{{ iframe_url }}" width="100%" style="border:none" class="myIframe"></iframe>                
+        <script type="text/javascript" language="javascript">$('.myIframe').css('height', $(window).height()+'px');</script>
+    </div>
+</div>
+{% endblock %}

--- a/showup/tests.py
+++ b/showup/tests.py
@@ -396,7 +396,11 @@ class AuthenticatedViewTests(TestCase):
         self.assertEqual(self.response.status_code, 200)
 
     def test_authed_user_can_see_messages_page(self):
-        self.response = self.client.get(reverse("messages", args=(1, 1)))
+        self.response = self.client.get(reverse("messages", args=(2, 1)))
+        self.assertEqual(
+            self.response.context["iframe_url"],
+            "https://showup-nyc-messaging.herokuapp.com/1-2",
+        )  # test that the view correctly puts the smaller squad ID first
         self.assertEqual(self.response.status_code, 200)
 
 

--- a/showup/tests.py
+++ b/showup/tests.py
@@ -332,6 +332,14 @@ class MatchesViewTests(TestCase):
         response = self.client.get(reverse("matches"))
         self.assertEqual(response.status_code, 200)
 
+    def test_authed_user_can_see_messages(self):
+        self.response = self.client.get(reverse("messages", args=(2, 1)))
+        self.assertEqual(
+            self.response.context["iframe_url"],
+            "https://showup-nyc-messaging.herokuapp.com/1-2",
+        )  # test that the view correctly puts the smaller squad ID first
+        self.assertEqual(self.response.status_code, 200)
+
 
 class AuthenticatedViewTests(TestCase):
     def setUp(self):  # this logs in a test user for the subsequent test cases
@@ -395,13 +403,10 @@ class AuthenticatedViewTests(TestCase):
         self.response = self.client.get(reverse("events") + get)
         self.assertEqual(self.response.status_code, 200)
 
-    def test_authed_user_can_see_messages_page(self):
-        self.response = self.client.get(reverse("messages", args=(2, 1)))
-        self.assertEqual(
-            self.response.context["iframe_url"],
-            "https://showup-nyc-messaging.herokuapp.com/1-2",
-        )  # test that the view correctly puts the smaller squad ID first
-        self.assertEqual(self.response.status_code, 200)
+    def test_authed_user_cannot_see_messages_page_with_different_squad_id(self):
+        self.response = self.client.get(reverse("messages", args=(25, 1)))
+        self.assertEqual(self.response.status_code, 403)
+        # the test user can't access this page because their squad ID is not 25
 
 
 class UnauthenticatedViewTests(TestCase):

--- a/showup/tests.py
+++ b/showup/tests.py
@@ -395,6 +395,10 @@ class AuthenticatedViewTests(TestCase):
         self.response = self.client.get(reverse("events") + get)
         self.assertEqual(self.response.status_code, 200)
 
+    def test_authed_user_can_see_messages_page(self):
+        self.response = self.client.get(reverse("messages", args=(1, 1)))
+        self.assertEqual(self.response.status_code, 200)
+
 
 class UnauthenticatedViewTests(TestCase):
     def test_unauthed_user_cannot_see_events(self):

--- a/showup/urls.py
+++ b/showup/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     path("s/<int:id>/edit", views.edit_squad, name="edit_squad"),
     path("<int:eid>/match", views.event_stack, name="event_stack"),
     path("avatar/", include("avatar.urls")),
+    path("messages/<int:squad1>-<int:squad2>", views.messages, name="messages"),
 ]
 
 if settings.DEBUG:

--- a/showup/views.py
+++ b/showup/views.py
@@ -213,3 +213,15 @@ def matches(request):
         uniq_events.add(match.event)
 
     return render(request, "matches.html", {"matches": matches, "events": uniq_events})
+
+
+@login_required
+def messages(request, squad1, squad2):
+    base_url = "https://showup-nyc-messaging.herokuapp.com/"
+    if squad1 > squad2:
+        squad1, squad2 = squad2, squad1
+    # we need only 1 chat room between any two squads so we choose arbitrarily
+    # to only have squad1 < squad2
+    return render(
+        request, "messages.html", {"iframe_url": f"{base_url}{squad1}-{squad2}"}
+    )

--- a/showup/views.py
+++ b/showup/views.py
@@ -217,11 +217,28 @@ def matches(request):
 
 @login_required
 def messages(request, squad1, squad2):
-    base_url = "https://showup-nyc-messaging.herokuapp.com/"
-    if squad1 > squad2:
-        squad1, squad2 = squad2, squad1
-    # we need only 1 chat room between any two squads so we choose arbitrarily
-    # to only have squad1 < squad2
-    return render(
-        request, "messages.html", {"iframe_url": f"{base_url}{squad1}-{squad2}"}
-    )
+    # We need to ensure that squad1 is the squad ID of the current user
+    # and that the user has matched with squad2
+    # because we don't want unauthorized people to access chat rooms
+    # We only need to check that squad1 is the current user's ID, not squad2
+    # because the links to the messages page always put the user's ID as the first
+    # parameter
+    uid = request.user.id
+    i_swiped_right = [x for x in Swipe.objects.filter(swiper__id=uid, direction=True)]
+    they_swiped_right = [
+        x.swiper for x in Swipe.objects.filter(swipee__id=uid, direction=True)
+    ]
+    matches = [
+        x.swipee.squad.id for x in i_swiped_right if x.swipee in they_swiped_right
+    ]
+    if squad1 != request.user.squad.id or squad2 not in matches:
+        raise PermissionDenied
+    else:
+        base_url = "https://showup-nyc-messaging.herokuapp.com/"
+        if squad1 > squad2:
+            squad1, squad2 = squad2, squad1
+        # we need only 1 chat room between any two squads so we choose arbitrarily
+        # to only have squad1 < squad2
+        return render(
+            request, "messages.html", {"iframe_url": f"{base_url}{squad1}-{squad2}"}
+        )


### PR DESCRIPTION
### Description

I implemented messaging. So now, the links on the "it's a match" popup and on the matches page work.

### Testing Directions

```
python manage.py makemigrations
python manage.py migrate
python manage.py pull_seatgeek_data
python manage.py make_users
```

1. Get the code from this PR
1. Make a match, click on the messages link in the match popup, see that it takes you to a messaging page. Send a message.
![match message](https://user-images.githubusercontent.com/13837978/69483147-d03a9100-0df1-11ea-82af-86b3d86a77bc.gif)
1. Log in as the other user in the match you just made, go to the matches page, click the messages link, see the message that you just sent as the other person.
![message after match](https://user-images.githubusercontent.com/13837978/69483148-d3ce1800-0df1-11ea-870e-c0bf58443341.gif)

### Miscellaneous Comments

* The chat rooms are based on the squad IDs so when the matching stack is modified to show squads instead of individual users, the messaging page will handle the squads correctly. This will require no or very little modification, depending on how exactly issue #143 is done.

### Checklist

- [x] I have written tests which have maintained/increased test coverage.
- [x] I ran `git merge develop` before submitting this PR.
- [x] I understand that I may have to run `git merge develop` again after submitting this PR since new changes may have been pulled into `develop`.
- [x] I understand that it is MY responsibility to make sure that this PR does not have any conflicts.