### PR TITLE
Events page bug

### DIFF
--- a/showup/templates/events.html
+++ b/showup/templates/events.html
@@ -116,16 +116,17 @@
 </div>
 
 <script>
-var position = 0;
-var main_card = document.getElementsByClassName("col-9 mh-100 overflow-auto py-2")[0];
-if (sessionStorage.getItem('scrollVertical')) {
+  var position = 0;
+  var main_card = document.getElementsByClassName("col-9 mh-100 overflow-auto py-2")[0];
+  if (sessionStorage.getItem('scrollVertical')) {
     position = sessionStorage.getItem('scrollVertical');
-}
-main_card.scrollTop = position;
+  }
+  main_card.scrollTop = position;
 
-function SetScrollPosition() {
+  function SetScrollPosition() {
     scrollVertical = main_card.scrollTop;
     sessionStorage.setItem('scrollVertical', scrollVertical);
-}
+  }
 </script>
+
 {% endblock %}

--- a/showup/templates/events.html
+++ b/showup/templates/events.html
@@ -100,8 +100,8 @@
                                     <p class="card-text">{{event.venue_name}} on {{event.datetime}}</p>
                                     <div class="text-center">
                                         <form action="" method="get">
-                                            <button class="btn btn-sm shadow {% if event.id in interested_list %}btn-primary{% endif %}" type="submit" name="interested" value={{event.id}} id = "interested">Interested</button>
-                                            <button class="btn btn-sm shadow {% if event.id in going_list %}btn-primary{% endif %}" type="submit" name="going" value={{event.id}} id = "going">Going</button>
+                                            <button class="btn btn-sm shadow {% if event.id in interested_list %}btn-primary{% endif %}" type="submit" name="interested" value={{event.id}} onclick = "SetScrollPosition()">Interested</button>
+                                            <button class="btn btn-sm shadow {% if event.id in going_list %}btn-primary{% endif %}" type="submit" name="going" value={{event.id}} onclick = "SetScrollPosition()">Going</button>
                                         </form>
                                     </div>
                                 </div>
@@ -116,16 +116,16 @@
 </div>
 
 <script>
-    $(document).ready(function(){
-        $("#interested").click(function(){
-            alert("this is interested!!");
-        });
-        
-        $("#going").click(function(){
-            alert("this is going!!");
-        });
-        
-    })
-</script>
+var position = 0;
+var main_card = document.getElementsByClassName("col-9 mh-100 overflow-auto py-2")[0];
+if (sessionStorage.getItem('scrollVertical')) {
+    position = sessionStorage.getItem('scrollVertical');
+}
+main_card.scrollTop = position;
 
+function SetScrollPosition() {
+    scrollVertical = main_card.scrollTop;
+    sessionStorage.setItem('scrollVertical', scrollVertical);
+}
+</script>
 {% endblock %}

--- a/showup/templates/events.html
+++ b/showup/templates/events.html
@@ -100,8 +100,8 @@
                                     <p class="card-text">{{event.venue_name}} on {{event.datetime}}</p>
                                     <div class="text-center">
                                         <form action="" method="get">
-                                            <button class="btn btn-sm shadow {% if event.id in interested_list %}btn-primary{% endif %}" type="submit" name="interested" value={{event.id}}>Interested</button>
-                                            <button class="btn btn-sm shadow {% if event.id in going_list %}btn-primary{% endif %}" type="submit" name="going" value={{event.id}}>Going</button>
+                                            <button class="btn btn-sm shadow {% if event.id in interested_list %}btn-primary{% endif %}" type="submit" name="interested" value={{event.id}} id = "interested">Interested</button>
+                                            <button class="btn btn-sm shadow {% if event.id in going_list %}btn-primary{% endif %}" type="submit" name="going" value={{event.id}} id = "going">Going</button>
                                         </form>
                                     </div>
                                 </div>
@@ -114,5 +114,18 @@
         </div> <!-- closes column that holds card with all events -->
     </div> <!-- closes row that holds everything -->
 </div>
+
+<script>
+    $(document).ready(function(){
+        $("#interested").click(function(){
+            alert("this is interested!!");
+        });
+        
+        $("#going").click(function(){
+            alert("this is going!!");
+        });
+        
+    })
+</script>
 
 {% endblock %}

--- a/showup/templates/events.html
+++ b/showup/templates/events.html
@@ -81,7 +81,7 @@
                 </div>
             </div>
         </div>
-        <div class="col-9 mh-100 overflow-auto py-2">
+        <div class="col-9 mh-100 overflow-auto py-2" onscroll="SetScrollPosition()">
             <div class="card shadow">
                 <div class="card-body">
                     <h2 class="card-title text-center">Events</h2>
@@ -100,8 +100,8 @@
                                     <p class="card-text">{{event.venue_name}} on {{event.datetime}}</p>
                                     <div class="text-center">
                                         <form action="" method="get">
-                                            <button class="btn btn-sm shadow {% if event.id in interested_list %}btn-primary{% endif %}" type="submit" name="interested" value={{event.id}} onclick = "SetScrollPosition()">Interested</button>
-                                            <button class="btn btn-sm shadow {% if event.id in going_list %}btn-primary{% endif %}" type="submit" name="going" value={{event.id}} onclick = "SetScrollPosition()">Going</button>
+                                            <button class="btn btn-sm shadow {% if event.id in interested_list %}btn-primary{% endif %}" type="submit" name="interested" value={{event.id}}>Interested</button>
+                                            <button class="btn btn-sm shadow {% if event.id in going_list %}btn-primary{% endif %}" type="submit" name="going" value={{event.id}}>Going</button>
                                         </form>
                                     </div>
                                 </div>

--- a/showup/views.py
+++ b/showup/views.py
@@ -13,7 +13,9 @@ def home(request):
 
 @login_required
 def events(request):
-    filter = ConcertFilter(request.GET, queryset=Concert.objects.all().order_by('datetime'))
+    filter = ConcertFilter(
+        request.GET, queryset=Concert.objects.all().order_by("datetime")
+    )
     context = {
         "filter": filter,
         "interested_list": request.user.interested.values_list("id", flat=True),

--- a/showup/views.py
+++ b/showup/views.py
@@ -13,7 +13,7 @@ def home(request):
 
 @login_required
 def events(request):
-    filter = ConcertFilter(request.GET, queryset=Concert.objects.all())
+    filter = ConcertFilter(request.GET, queryset=Concert.objects.all().order_by('datetime'))
     context = {
         "filter": filter,
         "interested_list": request.user.interested.values_list("id", flat=True),


### PR DESCRIPTION
### Description

1. Add javascript to save vertical scroll position for events card.
2. Use the stored scroll position whenever events page is revisited in the current session. Session is terminated when the current tab is closed and a new session is created and the scroll position is also reset to 0.
3. scroll position is stored in local storage of browser.
3. Fixed ordering of events by date in asc.

### Testing Directions

```
python manage.py makemigrations
python manage.py migrate
python manage.py pull_seatgeek_data
python manage.py make_users
```
1. Open the events page. Mark an event as interested/going. Check if the scroll position is maintained.

2. Scroll a bit to mark an event as interested/going for an event way down at the bottom. Check if scroll position is maintained.

3. Change to any other tab other than /events and revisit the /events tab to check the scroll position. It should take you the same position where you last left.


![scrollposition](https://user-images.githubusercontent.com/38910831/69498035-7d281300-0eb1-11ea-9d63-9b32ea67a4aa.gif)

### Miscellaneous Comments

1. Made changes to store scroll position without having to necessarily having to click interested/going buttons

### Checklist

- [x] I have written tests which have maintained/increased test coverage.
- [x] I ran `git merge develop` before submitting this PR.
- [x] I understand that I may have to run `git merge develop` again after submitting this PR since new changes may have been pulled into `develop`.
- [x] I understand that it is MY responsibility to make sure that this PR does not have any conflicts.