### PR TITLE
178 remove from squad

### DIFF
--- a/showup/forms.py
+++ b/showup/forms.py
@@ -32,4 +32,4 @@ class CustomUserChangeForm(UserChangeForm):
 
 
 class SquadForm(forms.Form):
-    email = forms.EmailField()
+    email = forms.EmailField(required=False)

--- a/showup/templates/edit_squad.html
+++ b/showup/templates/edit_squad.html
@@ -1,4 +1,5 @@
 {% extends 'header.html' %}
+
 {% block content %}
 
 <div style="position:relative; top:20px">
@@ -15,11 +16,15 @@
 
         <form method='POST'>
           {% csrf_token %}
+
           <div class="form-group my-3">
             <input type="email" name="email" class="form-control" placeholder="email address">
           </div>
+
           <button type="submit" name="add" class="btn btn-block btn-primary shadow lift">Add User</button>
-          <button type="submit" name="remove" class="btn btn-block btn-primary shadow lift">Remove Yourself</button>
+          {% if squad_size > 1 %}
+            <button type="submit" name="leave" class="btn btn-block btn-primary shadow lift">Leave Squad</button>
+          {% endif %}
         </form>
       </div>
     </div>

--- a/showup/templates/edit_squad.html
+++ b/showup/templates/edit_squad.html
@@ -16,9 +16,10 @@
         <form method='POST'>
           {% csrf_token %}
           <div class="form-group my-3">
-            <input type="email" name="email" class="form-control" placeholder="email address" required>
+            <input type="email" name="email" class="form-control" placeholder="email address">
           </div>
-          <button type="submit" class="btn btn-block btn-primary shadow lift">Add User</button>
+          <button type="submit" name="add" class="btn btn-block btn-primary shadow lift">Add User</button>
+          <button type="submit" name="remove" class="btn btn-block btn-primary shadow lift">Remove Yourself</button>
         </form>
       </div>
     </div>

--- a/showup/templates/squad.html
+++ b/showup/templates/squad.html
@@ -30,10 +30,10 @@
                 </div>
               {% endfor %}
             </div>
+            <center>
+              <a style = "position:relative; top:15px" class="btn btn-primary" href="{% url 'edit_squad' user.squad.id %}">Edit Your Squad</a>
+            </center>
           </div>
-          <center>
-            <a style = "position:relative; top:15px" class="btn btn-primary" href="{% url 'edit_squad' user.squad.id %}">Edit Your Squad</a>
-          </center>
         </div> <!-- closes body of big card that holds all events -->
       </div> <!-- closes big card that holds all events -->
     </div> <!-- closes column that holds card with all events -->

--- a/showup/tests.py
+++ b/showup/tests.py
@@ -294,7 +294,7 @@ class EditSquadViewTests(TestCase):
         users = CustomUser.objects.filter(squad=1)
         self.assertEqual(users.count(), 1)
 
-    def test_editsquad_add_remove(self):
+    def test_editsquad_add_leave(self):
         # Create form data.
         data = {"add": "", "email": "jfallon@example.com"}
 
@@ -314,6 +314,43 @@ class EditSquadViewTests(TestCase):
         # Ensure the POST request was successful.
         users = CustomUser.objects.filter(squad=1)
         self.assertEqual(users.count(), 1)
+
+    def test_editsquad_leave_one(self):
+        # Create form data.
+        data = {"leave": ""}
+
+        # Send a POST request containing the form data.
+        response = self.client.post(reverse("edit_squad", kwargs={"id": 1}), data=data)
+
+        # Ensure the POST request returns PermissionDenied.
+        self.assertEqual(response.status_code, 403)
+
+    def test_editsquad_malformed_post(self):
+        # Create form data.
+        data = {"remove": ""}
+
+        # Send a POST request containing the form data.
+        response = self.client.post(reverse("edit_squad", kwargs={"id": 1}), data=data)
+
+        # Ensure the POST request returns PermissionDenied.
+        self.assertEqual(response.status_code, 403)
+
+    def test_editsquad_get(self):
+        # Send a GET request.
+        response = self.client.get(reverse("edit_squad", kwargs={"id": 1}))
+
+        # Ensure the POST request was successful.
+        self.assertEqual(response.status_code, 200)
+
+    def test_editsquad_edit_other_squad(self):
+        # Create form data.
+        data = {"add": "", "email": "jfallon@example.com"}
+
+        # Send a POST request containing the form data.
+        response = self.client.post(reverse("edit_squad", kwargs={"id": 2}), data=data)
+
+        # Ensure the POST request returns PermissionDenied.
+        self.assertEqual(response.status_code, 403)
 
 
 class MatchesViewTests(TestCase):

--- a/showup/tests.py
+++ b/showup/tests.py
@@ -259,7 +259,7 @@ class EditSquadViewTests(TestCase):
 
     def test_editsquad_basic(self):
         # Create form data.
-        data = {"email": "jfallon@example.com", "submit": "add"}
+        data = {"email": "jfallon@example.com", "add": "add"}
 
         # Send a POST request containing the form data.
         self.client.post(reverse("edit_squad", kwargs={"id": 1}), data=data)

--- a/showup/tests.py
+++ b/showup/tests.py
@@ -290,6 +290,17 @@ class EditSquadViewTests(TestCase):
         users = CustomUser.objects.filter(squad=1)
         self.assertEqual(len(users), 1)
 
+    def test_editsquad_remove(self):
+        # Create form data.
+        data = {"email": "jfallon@example.com", "remove": "remove"}
+
+        # Send a POST request containing the form data.
+        self.client.post(reverse("edit_squad", kwargs={"id": 1}), data=data)
+
+        # Ensure the POST request was successful.
+        users = CustomUser.objects.filter(squad=1)
+        self.assertEqual(len(users), 1)
+
 
 class MatchesViewTests(TestCase):
     def setUp(self):

--- a/showup/tests.py
+++ b/showup/tests.py
@@ -259,7 +259,7 @@ class EditSquadViewTests(TestCase):
 
     def test_editsquad_basic(self):
         # Create form data.
-        data = {"email": "jfallon@example.com"}
+        data = {"email": "jfallon@example.com", "submit": "add"}
 
         # Send a POST request containing the form data.
         self.client.post(reverse("edit_squad", kwargs={"id": 1}), data=data)

--- a/showup/tests.py
+++ b/showup/tests.py
@@ -238,28 +238,32 @@ class EditSquadViewTests(TestCase):
     def setUp(self):
         # Create and save user one.
         email, password = "jspringer@example.com", "heyhey123"
-        squad = Squad(id=1)
-        squad.save()
+        squad = Squad.objects.create(id=1)
         user = CustomUser.objects.create_user(
             username=email, email=email, password=password, squad=squad
         )
-        EmailAddress.objects.get_or_create(id=1, user=user, verified=True)
 
         # Login user one.
+        EmailAddress.objects.create(id=1, user=user, verified=True)
         self.client.login(username=email, password=password)
 
         # Create and save user two.
         email, password = "jfallon@example.com", "heyhey123"
-        squad = Squad(id=2)
-        squad.save()
+        squad = Squad.objects.create(id=2)
         user = CustomUser.objects.create_user(
             username=email, email=email, password=password, squad=squad
         )
-        user.save()
+
+        # Create and save user three.
+        email, password = "jkimmel@example.com", "heyhey123"
+        squad = Squad.objects.create(id=3)
+        user = CustomUser.objects.create_user(
+            username=email, email=email, password=password, squad=squad
+        )
 
     def test_editsquad_basic(self):
         # Create form data.
-        data = {"email": "jfallon@example.com", "add": "add"}
+        data = {"add": "", "email": "jfallon@example.com"}
 
         # Send a POST request containing the form data.
         self.client.post(reverse("edit_squad", kwargs={"id": 1}), data=data)
@@ -270,36 +274,46 @@ class EditSquadViewTests(TestCase):
 
     def test_editsquad_already_in_squad(self):
         # Create form data.
-        data = {"email": "jspringer@example.com"}
+        data = {"add": "", "email": "jspringer@example.com"}
 
         # Send a POST request containing the form data.
         self.client.post(reverse("edit_squad", kwargs={"id": 1}), data=data)
 
         # Ensure the POST request was successful.
         users = CustomUser.objects.filter(squad=1)
-        self.assertEqual(len(users), 1)
+        self.assertEqual(users.count(), 1)
 
     def test_editsquad_email_does_not_exist(self):
         # Create form data.
-        data = {"email": "jkimmel@example.com"}
+        data = {"add": "", "email": "jseinfeld@example.com"}
 
         # Send a POST request containing the form data.
         self.client.post(reverse("edit_squad", kwargs={"id": 1}), data=data)
 
         # Ensure the POST request was successful.
         users = CustomUser.objects.filter(squad=1)
-        self.assertEqual(len(users), 1)
+        self.assertEqual(users.count(), 1)
 
-    def test_editsquad_remove(self):
+    def test_editsquad_add_remove(self):
         # Create form data.
-        data = {"email": "jfallon@example.com", "remove": "remove"}
+        data = {"add": "", "email": "jfallon@example.com"}
 
         # Send a POST request containing the form data.
         self.client.post(reverse("edit_squad", kwargs={"id": 1}), data=data)
 
         # Ensure the POST request was successful.
         users = CustomUser.objects.filter(squad=1)
-        self.assertEqual(len(users), 1)
+        self.assertEqual(users.count(), 2)
+
+        # Create form data.
+        data = {"leave": ""}
+
+        # Send a POST request containing the form data.
+        self.client.post(reverse("edit_squad", kwargs={"id": 1}), data=data)
+
+        # Ensure the POST request was successful.
+        users = CustomUser.objects.filter(squad=1)
+        self.assertEqual(users.count(), 1)
 
 
 class MatchesViewTests(TestCase):

--- a/showup/views.py
+++ b/showup/views.py
@@ -92,7 +92,6 @@ def edit_squad(request, id):
             my_squad = request.user.squad
 
             if "add" in request.POST:
-
                 # Get their squad and their members.
                 try:
                     their_squad = CustomUser.objects.get(
@@ -118,7 +117,14 @@ def edit_squad(request, id):
                 Squad.objects.get(id=their_squad.id).delete()
 
             elif "remove" in request.POST:
-                print(request.user.squad)
+                # If you are not alone in a squad, change squad id.
+                if CustomUser.objects.filter(squad=my_squad).count() > 1:
+                    me = CustomUser.objects.get(id=request.user.id)
+                    me.squad = Squad.objects.create()
+                    me.save()
+                # If you are alone in a squad do nothing.
+                else:
+                    return render(request, "edit_squad.html", {"form": form})
 
             return redirect(reverse("squad", kwargs={"id": id}))
         return render(request, "edit_squad.html", {"form": form})

--- a/showup/views.py
+++ b/showup/views.py
@@ -91,27 +91,34 @@ def edit_squad(request, id):
             # Get my squad.
             my_squad = request.user.squad
 
-            # Get their squad and their members.
-            try:
-                their_squad = CustomUser.objects.get(email=request.POST["email"]).squad
+            if "add" in request.POST:
 
-                # We are already in the same squad.
-                if my_squad.id == their_squad.id:
+                # Get their squad and their members.
+                try:
+                    their_squad = CustomUser.objects.get(email=request.POST["email"]).squad
+
+                    # We are already in the same squad.
+                    if my_squad.id == their_squad.id:
+                        # TODO: Output some sort of message.
+                        return render(request, "edit_squad.html", {"form": form})
+
+                    their_members = CustomUser.objects.filter(squad=their_squad)
+                except CustomUser.DoesNotExist:
                     # TODO: Output some sort of message.
                     return render(request, "edit_squad.html", {"form": form})
 
-                their_members = CustomUser.objects.filter(squad=their_squad)
-            except CustomUser.DoesNotExist:
-                # TODO: Output some sort of message.
-                return render(request, "edit_squad.html", {"form": form})
+                # Merge squads.
+                for member in their_members:
+                    member.squad = my_squad
+                    member.save()
 
-            # Merge squads.
-            for member in their_members:
-                member.squad = my_squad
-                member.save()
+                # Delete their old squad.
+                Squad.objects.get(id=their_squad.id).delete()
 
-            # Delete their old squad.
-            Squad.objects.get(id=their_squad.id).delete()
+            elif "remove" in request.POST:
+                print(request.user.squad)
+                
+                
 
             return redirect(reverse("squad", kwargs={"id": id}))
         return render(request, "edit_squad.html", {"form": form})

--- a/showup/views.py
+++ b/showup/views.py
@@ -5,9 +5,6 @@ from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import redirect, render, reverse
 from .filters import ConcertFilter
-# django-friends package
-from django.contrib.auth.models import User
-from friendship.models import Friend, Follow, Block
 
 
 def home(request):

--- a/showup/views.py
+++ b/showup/views.py
@@ -95,7 +95,9 @@ def edit_squad(request, id):
 
                 # Get their squad and their members.
                 try:
-                    their_squad = CustomUser.objects.get(email=request.POST["email"]).squad
+                    their_squad = CustomUser.objects.get(
+                        email=request.POST["email"]
+                    ).squad
 
                     # We are already in the same squad.
                     if my_squad.id == their_squad.id:
@@ -117,8 +119,6 @@ def edit_squad(request, id):
 
             elif "remove" in request.POST:
                 print(request.user.squad)
-                
-                
 
             return redirect(reverse("squad", kwargs={"id": id}))
         return render(request, "edit_squad.html", {"form": form})

--- a/showup/views.py
+++ b/showup/views.py
@@ -5,6 +5,9 @@ from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import redirect, render, reverse
 from .filters import ConcertFilter
+# django-friends package
+from django.contrib.auth.models import User
+from friendship.models import Friend, Follow, Block
 
 
 def home(request):
@@ -122,6 +125,7 @@ def edit_squad(request, id):
                     me = CustomUser.objects.get(id=request.user.id)
                     me.squad = Squad.objects.create()
                     me.save()
+                    return redirect(reverse("squad", kwargs={"id": me.squad.id}))
                 # If you are alone in a squad do nothing.
                 else:
                     return render(request, "edit_squad.html", {"form": form})


### PR DESCRIPTION
### Description

Allow users to leave their squad. 

### Testing Directions

```
./setup
python3 manage.py runserver
```

1.   Log in as vm1564@nyu.edu and navigate to http://127.0.0.1:8000/s/1/edit. See that the "Leave Squad" button is not visible since you are in a squad containing only yourself.
1.   Add vm1564+1@nyu.edu to your squad. You will be redirected to http://127.0.0.1:8000/s/1 where you will see "Vik" and "Vik1" on the page.
1.   Click "Edit Your Squad". See that the "Leave Squad" button is now visible.
1.   Click "Leave Squad". You are now redirected to http://127.0.0.1:8000/s/38, where 38 is your new squad id. This is because you left your old squad and a new one was created for you.
1.   Repeat this test with a squad of more than 2 users. You will get the same result.

### Miscellaneous Comments

*   Button styling is not good, should change in future. 

### Checklist

- [x] I have written tests which have maintained/increased test coverage.
- [x] I ran `git merge develop` before submitting this PR.
- [x] I understand that I may have to run `git merge develop` again after submitting this PR since new changes may have been pulled into `develop`.
- [x] I understand that it is MY responsibility to make sure that this PR does not have any conflicts.