### PR TITLE
add code to print error messages

### DIFF
--- a/showup/templates/account/login.html
+++ b/showup/templates/account/login.html
@@ -33,6 +33,12 @@
                 <div class="form-group my-3">
                   <input type="password" name="password" required class="form-control" placeholder="password">
                 </div>
+                
+                {% for error in form.non_field_errors %}
+                    {% if "password" in error %}
+                        <strong style='color:red;'>{{error}}</strong>
+                    {% endif %}
+                {% endfor %}
 
                 <button type="submit" class="btn btn-block btn-primary shadow lift">Let me in.</button>
                 <a class="nav-link" href="{% url 'account_reset_password' %}">Forgot your password?</a>


### PR DESCRIPTION
### Description

Added code snippet to templates/account.html to print default error message for invalid email id/password. We should stick with default messages from allauth for now.

### Testing Directions

```
python manage.py makemigrations
python manage.py migrate
python manage.py pull_seatgeek_data
python manage.py make_users
```

1.  Try using a correct email id and password combination. Check if error is not displayed.
2.  Try using a incorrect password. Check if error is displayed in red.
3. Try using an incorrect email id. Check if error is displayed in red.

### Miscellaneous Comments

```life is chill```

### Checklist

- [X] I have written tests which have maintained/increased test coverage.
- [X] I ran `git merge develop` before submitting this PR.
- [X] I understand that I may have to run `git merge develop` again after submitting this PR since new changes may have been pulled into `develop`.
- [X] I understand that it is MY responsibility to make sure that this PR does not have any conflicts.