### PR TITLE
Replace bug-template.md with the one from the instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-template.md
+++ b/.github/ISSUE_TEMPLATE/bug-template.md
@@ -1,18 +1,32 @@
 ---
-name: Bug Report
-about: File a bug report.
-title: BR: <title>
+name: Bug
+about: Add an issue for a Bug
+title: <general summary of issue>
 labels: ''
 assignees: ''
 ---
 
-### Steps to Reproduce
+Issue tracker is ONLY used for reporting bugs. New features should be discussed in its own thread on the #general channel of slack.
 
-1.  Show
-1.  Me
-1.  The
-1.  Error
+<!--- Provide a general summary of the issue in the Title above -->
 
-### Expected Behavior
+## Expected Behavior
+<!--- Tell us what should happen -->
 
-The above behavior is wrong. Our product should do <this>.
+## Current Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+
+## Ideas for Improvement
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+
+## Steps to Reproduce
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Context (Environment)
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->


### PR DESCRIPTION
### Description

I asked Dan why our bug template isn't given as an option when making a new issue. He recommended replacing our template with the one from the instructions, so that's what I did.

### Testing Directions

1. I don't know of any way to test this