### PR TITLE
PR for #183: Include Ages on Match Stack

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ django-heroku
 django-session-timeout
 flake8
 gunicorn
+python-dateutil
 requests

--- a/showup/models.py
+++ b/showup/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.contrib.auth.models import AbstractUser
+from datetime import date
 
 
 class Genre(models.Model):
@@ -57,6 +58,16 @@ class CustomUser(AbstractUser):
 
     def __str__(self):
         return self.email
+
+    def get_age(self):
+        today = date.today()
+        if self.date_of_birth is None:
+            return -1
+        else:
+            bday = self.date_of_birth
+            return (
+                today.year - bday.year - ((today.month, today.day) < (bday.month, bday.day))
+            )
 
 
 class Swipe(models.Model):

--- a/showup/models.py
+++ b/showup/models.py
@@ -66,7 +66,9 @@ class CustomUser(AbstractUser):
         else:
             bday = self.date_of_birth
             return (
-                today.year - bday.year - ((today.month, today.day) < (bday.month, bday.day))
+                today.year
+                - bday.year
+                - ((today.month, today.day) < (bday.month, bday.day))
             )
 
 

--- a/showup/models.py
+++ b/showup/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.contrib.auth.models import AbstractUser
 from datetime import date
+from dateutil.relativedelta import relativedelta
 
 
 class Genre(models.Model):
@@ -60,16 +61,7 @@ class CustomUser(AbstractUser):
         return self.email
 
     def get_age(self):
-        today = date.today()
-        if self.date_of_birth is None:
-            return -1
-        else:
-            bday = self.date_of_birth
-            return (
-                today.year
-                - bday.year
-                - ((today.month, today.day) < (bday.month, bday.day))
-            )
+        return relativedelta(date.today(), self.date_of_birth).years
 
 
 class Swipe(models.Model):

--- a/showup/templates/match.html
+++ b/showup/templates/match.html
@@ -20,7 +20,7 @@
               {% for u in users %}
                 {% if u.squad.id == swipee.id %}
                   <div class="col">
-                    {% avatar u %} &nbsp <a href="{% url 'user' u.id %}">{{ u.first_name }}</a><br><br>
+                    {% avatar u %} &nbsp <a href="{% url 'user' u.id %}">{{ u.first_name }}{% if u.get_age > 0 %}, {{ u.get_age }}{% endif %}</a><br><br>
                   </div>
                 {% endif %}
               {% endfor %}

--- a/showup/tests.py
+++ b/showup/tests.py
@@ -62,10 +62,12 @@ class CustomUserModelTests(TestCase):
 
     def test_get_age_function_for_blank_birthday(self):
         blank_bday_user = CustomUser()
-        self.assertEqual(blank_bday_user.get_age(), -1)
+        self.assertEqual(blank_bday_user.get_age(), 0)
 
     def test_get_age_function_for_real_birthday(self):
-        hundred_years_ago = datetime.datetime.now() - relativedelta(years=100)
+        hundred_years_ago = (
+            datetime.datetime.now() - relativedelta(years=100) - relativedelta(days=5)
+        )
         real_bday_user = CustomUser(date_of_birth=hundred_years_ago)
         self.assertEqual(real_bday_user.get_age(), 100)
 

--- a/showup/tests.py
+++ b/showup/tests.py
@@ -1,4 +1,5 @@
 import datetime
+from dateutil.relativedelta import relativedelta
 
 from .models import Concert, CustomUser, Genre, Request, Squad, Swipe
 from allauth.account.admin import EmailAddress
@@ -58,6 +59,15 @@ class CustomUserModelTests(TestCase):
         # Ensure the POST request was successful.
         user = CustomUser.objects.get(email="jspringer@example.com")
         self.assertEqual(user.last_name, "Springer")
+    
+    def test_get_age_function_for_blank_birthday(self):
+        blank_bday_user = CustomUser()
+        self.assertEqual(blank_bday_user.get_age(), -1)
+
+    def test_get_age_function_for_real_birthday(self):
+        hundred_years_ago = datetime.datetime.now() - relativedelta(years=100)
+        real_bday_user = CustomUser(date_of_birth=hundred_years_ago)
+        self.assertEqual(real_bday_user.get_age(), 100)
 
 
 class SwipeModelTests(TestCase):

--- a/showup/tests.py
+++ b/showup/tests.py
@@ -59,7 +59,7 @@ class CustomUserModelTests(TestCase):
         # Ensure the POST request was successful.
         user = CustomUser.objects.get(email="jspringer@example.com")
         self.assertEqual(user.last_name, "Springer")
-    
+
     def test_get_age_function_for_blank_birthday(self):
         blank_bday_user = CustomUser()
         self.assertEqual(blank_bday_user.get_age(), -1)


### PR DESCRIPTION
### Description

* Made the age of each user show on the matching stack, like Tinder
![image](https://user-images.githubusercontent.com/13837978/70090472-3d1b0b80-15e8-11ea-9420-83e4f82954ac.png)


### Testing Directions

```
python manage.py makemigrations
python manage.py migrate
python manage.py pull_seatgeek_data
python manage.py make_users
```

1. Make people with no birthday interested in an event and look at the matching stack for that event. See that no age is displayed.
![image](https://user-images.githubusercontent.com/13837978/70088485-5e79f880-15e4-11ea-958f-db983080ccc7.png)
1. Add birthdays to those users in the admin interface and look at the stack again. See that their ages are shown, as desired.
![image](https://user-images.githubusercontent.com/13837978/70088606-8f5a2d80-15e4-11ea-94bf-607f7619235b.png)


### Miscellaneous Comments

* Users who sign up on ShowUp can't leave their birthday blank but we should test that case anyway because the test users that our make_users script makes don't have birthdays, and those are the users our classmates will be using

### Checklist

- [x] I have written tests which have maintained/increased test coverage.
- [x] I ran `git merge develop` before submitting this PR.
- [x] I understand that I may have to run `git merge develop` again after submitting this PR since new changes may have been pulled into `develop`.
- [x] I understand that it is MY responsibility to make sure that this PR does not have any conflicts.